### PR TITLE
Include more error data in HubspotClientError

### DIFF
--- a/hubspot/connection/__init__.py
+++ b/hubspot/connection/__init__.py
@@ -29,7 +29,7 @@ from pyrecord import Record
 from requests.adapters import HTTPAdapter
 from requests.auth import AuthBase
 from requests.sessions import Session
-from voluptuous import Schema
+from voluptuous import Optional, Schema
 
 from hubspot.connection._validators import Constant
 from hubspot.connection.exc import HubspotAuthenticationError
@@ -48,6 +48,7 @@ _HUBSPOT_ERROR_RESPONSE_SCHEMA = Schema(
         'status': Constant('error'),
         'message': unicode,
         'requestId': unicode,
+        Optional('failureMessages'): list,
         },
     required=True,
     extra=True,

--- a/hubspot/connection/__init__.py
+++ b/hubspot/connection/__init__.py
@@ -204,6 +204,7 @@ class PortalConnection(object):
             raise exception_class(
                 error_data['message'],
                 error_data['requestId'],
+                error_data,
                 )
         elif 500 <= response.status_code < 600:
             raise HubspotServerError(response.reason, response.status_code)

--- a/hubspot/connection/__init__.py
+++ b/hubspot/connection/__init__.py
@@ -205,6 +205,7 @@ class PortalConnection(object):
                 error_data['message'],
                 error_data['requestId'],
                 error_data,
+                response.status_code,
                 )
         elif 500 <= response.status_code < 600:
             raise HubspotServerError(response.reason, response.status_code)

--- a/hubspot/connection/exc.py
+++ b/hubspot/connection/exc.py
@@ -32,9 +32,11 @@ class HubspotClientError(HubspotException):
     :param unicode request_id:
 
     """
-    def __init__(self, msg, request_id, error_data):
+    def __init__(self, error_message, request_id, error_data):
         if error_data and 'failureMessages' in error_data:
-            msg = u'%s (%s)' % (msg, error_data['failureMessages'])
+            msg = u'%s (%s)' % (error_message, error_data['failureMessages'])
+        else:
+            msg = error_message
         super(HubspotClientError, self).__init__(msg)
 
         self.request_id = request_id

--- a/hubspot/connection/exc.py
+++ b/hubspot/connection/exc.py
@@ -32,7 +32,7 @@ class HubspotClientError(HubspotException):
     :param unicode request_id:
 
     """
-    def __init__(self, error_message, request_id, error_data):
+    def __init__(self, error_message, request_id, error_data=None):
         if error_data and 'failureMessages' in error_data:
             msg = u'%s (%s)' % (error_message, error_data['failureMessages'])
         else:

--- a/hubspot/connection/exc.py
+++ b/hubspot/connection/exc.py
@@ -32,10 +32,11 @@ class HubspotClientError(HubspotException):
     :param unicode request_id:
 
     """
-    def __init__(self, msg, request_id):
+    def __init__(self, msg, request_id, error_data):
         super(HubspotClientError, self).__init__(msg)
 
         self.request_id = request_id
+        self.error_data = error_data
 
 
 class HubspotAuthenticationError(HubspotClientError):

--- a/hubspot/connection/exc.py
+++ b/hubspot/connection/exc.py
@@ -31,15 +31,17 @@ class HubspotClientError(HubspotException):
 
     :param unicode request_id:
     :param dict optional error_data:
+    :param int optional http_status_code:
 
     """
-    def __init__(self, error_message, request_id, error_data=None):
+    def __init__(self, error_message, request_id, error_data=None, http_status_code=None):
         if error_data and 'failureMessages' in error_data:
             msg = u'%s (%s)' % (error_message, error_data['failureMessages'])
         else:
             msg = error_message
         super(HubspotClientError, self).__init__(msg)
 
+        self.http_status_code = http_status_code
         self.error_message = error_message
         self.request_id = request_id
         self.error_data = error_data

--- a/hubspot/connection/exc.py
+++ b/hubspot/connection/exc.py
@@ -39,6 +39,7 @@ class HubspotClientError(HubspotException):
             msg = error_message
         super(HubspotClientError, self).__init__(msg)
 
+        self.error_message = error_message
         self.request_id = request_id
         self.error_data = error_data
 

--- a/hubspot/connection/exc.py
+++ b/hubspot/connection/exc.py
@@ -30,6 +30,7 @@ class HubspotClientError(HubspotException):
     of 40X, except 401
 
     :param unicode request_id:
+    :param dict optional error_data:
 
     """
     def __init__(self, error_message, request_id, error_data=None):

--- a/hubspot/connection/exc.py
+++ b/hubspot/connection/exc.py
@@ -33,6 +33,8 @@ class HubspotClientError(HubspotException):
 
     """
     def __init__(self, msg, request_id, error_data):
+        if error_data and 'failureMessages' in error_data:
+            msg = u'%s (%s)' % (msg, error_data['failureMessages'])
         super(HubspotClientError, self).__init__(msg)
 
         self.request_id = request_id

--- a/hubspot/connection/exc.py
+++ b/hubspot/connection/exc.py
@@ -36,7 +36,7 @@ class HubspotClientError(HubspotException):
     """
     def __init__(self, error_message, request_id, error_data=None, http_status_code=None):
         if error_data and 'failureMessages' in error_data:
-            msg = u'%s (%s)' % (error_message, error_data['failureMessages'])
+            msg = u'{0} ({1!s})'.format(error_message, error_data['failureMessages'])
         else:
             msg = error_message
         super(HubspotClientError, self).__init__(msg)

--- a/hubspot/connection/exc.py
+++ b/hubspot/connection/exc.py
@@ -29,8 +29,8 @@ class HubspotClientError(HubspotException):
     HubSpot deemed the request invalid. This represents an HTTP response code
     of 40X, except 401
 
-    :param unicode request_id:
     :param unicode error_message: The error message returned by HubSpot
+    :param unicode request_id:
     :param dict optional error_data: The response data returned by HubSpot
     :param int optional http_status_code:
 

--- a/hubspot/connection/exc.py
+++ b/hubspot/connection/exc.py
@@ -30,7 +30,8 @@ class HubspotClientError(HubspotException):
     of 40X, except 401
 
     :param unicode request_id:
-    :param dict optional error_data:
+    :param unicode error_message: The error message returned by HubSpot
+    :param dict optional error_data: The response data returned by HubSpot
     :param int optional http_status_code:
 
     """

--- a/hubspot/connection/testing.py
+++ b/hubspot/connection/testing.py
@@ -64,9 +64,8 @@ class MockPortalConnection(object):
             return
 
         expected_api_call_count = len(self._expected_api_calls)
-        pending_api_call_count = expected_api_call_count - self._request_count
         error_message = \
-            '{} more requests were expected'.format(pending_api_call_count)
+            '{} requests were expected, but only {} calls were received'.format(expected_api_call_count, self._request_count)
         assert expected_api_call_count == self._request_count, error_message
 
     def send_get_request(self, url_path, query_string_args=None):

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -271,9 +271,22 @@ class TestErrorResponses(object):
 
         exception = context_manager.exception
         eq_(request_id, exception.request_id)
-        eq_(error_message, str(exception))
+        eq_("Errors found processing batch update ([{u'index': 0, u'error': {u'status': u'error', u'message': u'Email address  is invalid'}}])",
+            str(exception))
         eq_(invalid_emails, exception.error_data['invalidEmails'])
         eq_(failure_messages, exception.error_data['failureMessages'])
+
+    def test_str_client_exception_when_no_failure_messages(self):
+        request_id = get_uuid4_str()
+        error_message = 'Json node is missing child property'
+        error_data = {
+            'status': 'error',
+            'message': error_message,
+            'requestId': request_id,
+        }
+
+        exception = HubspotClientError(error_message, request_id, error_data)
+        eq_(error_message, str(exception))
 
 
 class TestAuthentication(object):

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -244,12 +244,25 @@ class TestErrorResponses(object):
 
     def test_client_error_response(self):
         request_id = get_uuid4_str()
-        error_message = 'Json node is missing child property'
+        error_message = 'Errors found processing batch update'
+        failure_messages = [
+            {
+                'index': 0,
+                'error': {
+                    'status': 'error',
+                    'message': 'Email address  is invalid'
+                }
+            }
+        ]
+        invalid_emails = ['']
         body_deserialization = {
             'status': 'error',
             'message': error_message,
-            'requestId': request_id,
-            }
+            'correlationId': '2ebc27ce-cc2d-4b81-99f3-01aa96e05206',
+            'invalidEmails': invalid_emails,
+            'failureMessages': failure_messages,
+            'requestId': request_id
+        }
         response_data_maker = _ResponseMaker(400, body_deserialization)
         connection = _MockPortalConnection(response_data_maker)
 
@@ -259,6 +272,8 @@ class TestErrorResponses(object):
         exception = context_manager.exception
         eq_(request_id, exception.request_id)
         eq_(error_message, str(exception))
+        eq_(invalid_emails, exception.error_data['invalidEmails'])
+        eq_(failure_messages, exception.error_data['failureMessages'])
 
 
 class TestAuthentication(object):

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -281,7 +281,7 @@ class TestErrorResponses(object):
         eq_(failure_messages, exception.error_data['failureMessages'])
         eq_(400, exception.http_status_code)
 
-    def test_str_client_exception_when_no_failure_messages(self):
+    def test_str_client_exception_without_failure_messages(self):
         request_id = get_uuid4_str()
         error_message = 'Json node is missing child property'
         error_data = {

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -250,7 +250,7 @@ class TestErrorResponses(object):
                 'index': 0,
                 'error': {
                     'status': 'error',
-                    'message': 'Email address  is invalid'
+                    'message': 'Email address  is invalid',
                 }
             }
         ]
@@ -261,7 +261,7 @@ class TestErrorResponses(object):
             'correlationId': '2ebc27ce-cc2d-4b81-99f3-01aa96e05206',
             'invalidEmails': invalid_emails,
             'failureMessages': failure_messages,
-            'requestId': request_id
+            'requestId': request_id,
         }
         response_data_maker = _ResponseMaker(400, body_deserialization)
         connection = _MockPortalConnection(response_data_maker)

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -276,6 +276,7 @@ class TestErrorResponses(object):
         eq_(error_message, exception.error_message)
         eq_(invalid_emails, exception.error_data['invalidEmails'])
         eq_(failure_messages, exception.error_data['failureMessages'])
+        eq_(400, exception.http_status_code)
 
     def test_str_client_exception_when_no_failure_messages(self):
         request_id = get_uuid4_str()

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -273,6 +273,7 @@ class TestErrorResponses(object):
         eq_(request_id, exception.request_id)
         eq_("Errors found processing batch update ([{u'index': 0, u'error': {u'status': u'error', u'message': u'Email address  is invalid'}}])",
             str(exception))
+        eq_(error_message, exception.error_message)
         eq_(invalid_emails, exception.error_data['invalidEmails'])
         eq_(failure_messages, exception.error_data['failureMessages'])
 
@@ -287,6 +288,7 @@ class TestErrorResponses(object):
 
         exception = HubspotClientError(error_message, request_id, error_data)
         eq_(error_message, str(exception))
+        eq_(error_message, exception.error_message)
 
 
 class TestAuthentication(object):

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -271,7 +271,10 @@ class TestErrorResponses(object):
 
         exception = context_manager.exception
         eq_(request_id, exception.request_id)
-        eq_("Errors found processing batch update ([{u'index': 0, u'error': {u'status': u'error', u'message': u'Email address  is invalid'}}])",
+        eq_("Errors found processing batch update "
+            "([{u'index': 0, u'error': "
+            "{u'status': u'error',"
+            " u'message': u'Email address  is invalid'}}])",
             str(exception))
         eq_(error_message, exception.error_message)
         eq_(invalid_emails, exception.error_data['invalidEmails'])

--- a/tests/test_testing_utils.py
+++ b/tests/test_testing_utils.py
@@ -189,7 +189,7 @@ class TestMockPortalConnection(object):
     def test_too_few_requests(self):
         connection = \
             self._make_connection_for_expected_api_call(_STUB_API_CALL_1)
-        error_message = '1 more requests were expected'
+        error_message = '1 requests were expected, but only 0 calls were received'
         with assert_raises_substring(AssertionError, error_message):
             with connection:
                 # Do not make any requests in the connection

--- a/tests/test_testing_utils.py
+++ b/tests/test_testing_utils.py
@@ -171,7 +171,7 @@ class TestMockPortalConnection(object):
 
     def test_unsuccessful_api_call(self):
         exception = \
-            HubspotAuthenticationError('Must authenticate', get_uuid4_str())
+            HubspotAuthenticationError('Must authenticate', get_uuid4_str(), {})
         expected_api_call = UnsuccessfulAPICall(
             _STUB_URL_PATH,
             'GET',


### PR DESCRIPTION
Including all error information returned by HubSpot aids troubleshooting and allows better error reporting to the user.

This branch also includes some other tweaks, for example a change to an error message. If you'd like to merge some of these changes but not others please let me know.
